### PR TITLE
Add a basic tox setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+envlist =
+    {py26,py27,pypy,py33,py34,py35}-sympy{073,074,075,master}, pep8, py35pep8
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    pypy: pypy
+    py33: python2.2
+    py34: python3.4
+    py35: python3.5
+
+setenv =
+    # This is required in order to get UTF-8 output inside of the subprocesses
+    # that our tests use.
+    LC_CTYPE = en_US.UTF-8
+deps =
+     unittest2
+     pexpect
+     sympy073: git+https://github.com/sympy/sympy.git@sympy-0.7.3
+     sympy074: git+https://github.com/sympy/sympy.git@sympy-0.7.4
+     sympy075: git+https://github.com/sympy/sympy.git@sympy-0.7.5
+     sympymaster: git+https://github.com/sympy/sympy.git
+
+commands =
+         python setup.py test
+         python mathics/test.py
+
+install_command =
+                pip install --pre {opts} {packages}
+
+[testenv:pep8]
+basepython = python2.7
+deps = flake8==2.3.0
+commands = flake8 .
+
+[testenv:py3pep8]
+basepython = python3.3
+deps = flake8==2.3.0
+commands = flake8 .
+
+[flake8]
+exclude = .tox,*.egg,build,_vendor,data
+select = E,W,F


### PR DESCRIPTION
You're no doubt familiar with the way Travis runs the test suite across
various versions of Python, with versions versions of sympy

Tox gives similar functionality on your development machine.

If you just run tox, it will run the tests defined in each environment -
in this case, there are 6 versions of python tested against 4 versions
of sympy each.

If you just want to test (for instance) py27 with sympy-master, you can
use `tox -e py26-sympymaster`

You can get a full list of all available environments with `tox -l`

Each combination will run in its own virtualenv; these are under .tox in
the project root.

I think I've managed to capture most of the logic expressed in the
travis.yml in this file
